### PR TITLE
Add direct-schema to the list of implementations on the website.

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -101,6 +101,7 @@ license of the project is also mentioned.</p>
     <li><a href="http://www.dojotoolkit.org/">Dojo</a>;</li>
     <li><a href="http://www.persvr.org/">Persevere</a> (modified BSD or AFL 2.0);</li>
     <li><a href="https://github.com/akidee/schema.js">schema.js</a>.</li>
+    <li><a href="http://github.com/IreneKnapp/direct-schema">direct-schema</a> (BSD);</li>
 </ul>
 
                 </div> <!-- class="span4" -->


### PR DESCRIPTION
Since I consider my direct-schema to be ready for prime time (it's embarrassingly lacking in documentation, but... other than that), here's a pull request which adds it to the list of implementations on the website.  I put it at the bottom of the list because I wasn't sure how it was sorted and didn't want to step on anybody's toes.  Thanks!
