### PR TITLE
fix indentation of 'Set of Products' example

### DIFF
--- a/example1.html
+++ b/example1.html
@@ -1,4 +1,3 @@
-
 <html>
 	<head>
 		<title>JSON Schema - Simple Example</title>
@@ -238,7 +237,7 @@
         "id": 3,
         "name": "A blue mouse",
         "price": 25.50,
-            "dimensions": {
+        "dimensions": {
             "length": 3.1,
             "width": 1.0,
             "height": 1.0


### PR DESCRIPTION
In the final summary section, the indentation of the 'dimensions' property in the item 'blue mouse' was misaligned from the other properties.
