### PR TITLE
Added Visual Studio to Software and example link to schemastore.org

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -63,7 +63,6 @@
 		<li><a href="example2.html">a more advanced example</a>, using JSON Schema to describe filesystem entries in a Unix-like /etc/fstab file.
 	</ul>
 	<p>The <a href="http://www.stsci.edu/">Space Telescope Science Institute</a> has also published an <a href="http://spacetelescope.github.io/understanding-json-schema/">guide aimed at schema authors</a>.
-	<p>For more JSON schemas, see the collection at <a href="http://schemastore.org">schemastore.org</a></p>
 </div>			</div>
 		</div>
 		<script src="style/js/json-highlight.js"></script>


### PR DESCRIPTION
Visual Studio 2013 now fully support auto-completion and description/type tooltips for any JSON document that's paired with/pointing to a JSON schema. 

---

Under examples, a new link has been added at the bottom pointing to schemastore.org. This website contains several JSON schema files for popular JSON documents, such as `package.json`, `.jshintrc` and `bower.json`. It's a great place to learn about some real-world JSON schema files that are being actively used today.
