### PR TITLE
Updated `calendar` to Draft v4

### DIFF
--- a/calendar
+++ b/calendar
@@ -1,19 +1,20 @@
 {
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "A representation of an event",
     "type": "object",
+    "required": [ "dtstart", "summary" ],
     "properties": {
         "dtstart": {
             "format": "date-time",
             "type": "string",
-            "description": "Event starting time",
-            "required": true
+            "description": "Event starting time"
         },
         "dtend": {
             "format": "date-time",
             "type": "string",
             "description": "Event ending time"
         },
-        "summary": { "type": "string", "required": true },
+        "summary": { "type": "string" },
         "location": { "type": "string" },
         "url": { "type": "string", "format": "uri" },
         "duration": {


### PR DESCRIPTION
The `calendar` schema was not in Draft v4 format, so I updated it. 2 changes was done:

1. Added `$schema` property pointing to v4 draft URI
2. Added root level `required` property