### PR TITLE
changed the format of "id" from "uri" to "uri-reference"

### DIFF
--- a/draft-04/schema
+++ b/draft-04/schema
@@ -29,7 +29,7 @@
     "properties": {
         "id": {
             "type": "string",
-            "format": "uri"
+            "format": "uri-reference"
         },
         "$schema": {
             "type": "string",


### PR DESCRIPTION
According to the JSON schema spec [draft 4, Section 7.1](http://json-schema.org/latest/json-schema-core.html#rfc.section.7.1), ids should be URI References, not URIs. This is supported by the examples given in the spec and in other parts of this metaschema, since things like "#schema1" and "#/definitions/schemaArray" are not URIs according to [RFC 3986, sections 4.1-2](http://tools.ietf.org/html/rfc3986#section-4.1) but are URI References.
