### PR TITLE
Include readOnly property

### DIFF
--- a/draft-04/hyper-schema
+++ b/draft-04/hyper-schema
@@ -101,7 +101,7 @@
             }
         },
         "readOnly": {
-            "type": boolean,
+            "type": "boolean",
             "description": "If true, the associated instance property SHOULD NOT be changed, and attempts to do so are expected to be rejected by a server."
         },
         "pathStart": {

--- a/draft-04/hyper-schema
+++ b/draft-04/hyper-schema
@@ -100,6 +100,10 @@
                 }
             }
         },
+        "readOnly": {
+            "type": boolean,
+            "description": "If true, the associated instance property SHOULD NOT be changed, and attempts to do so are expected to be rejected by a server."
+        },
         "pathStart": {
             "description": "Instances' URIs must start with this value for this schema to apply to them",
             "type": "string",


### PR DESCRIPTION
Given that this should only be defined on instance properties, I'm not 100% sure that this is in the right place, but I can't figure out how to make this _only_ valid for sub-objects of `"properties"`.
