### PR TITLE
Draft4: Added validation of JSON Reference

### DIFF
--- a/draft-04/schema
+++ b/draft-04/schema
@@ -23,6 +23,13 @@
             "items": { "type": "string" },
             "minItems": 1,
             "uniqueItems": true
+        },
+        "referenceObject": {
+            "type": "object",
+            "properties": {
+                "$ref" : { "type": "string" }
+            },
+            "additionalProperties": false
         }
     },
     "type": "object",
@@ -144,7 +151,8 @@
     },
     "dependencies": {
         "exclusiveMaximum": [ "maximum" ],
-        "exclusiveMinimum": [ "minimum" ]
+        "exclusiveMinimum": [ "minimum" ],
+        "$ref": { "$ref": "#/definitions/referenceObject" }
     },
     "default": {}
 }


### PR DESCRIPTION
Added validation of JSON Reference according to
http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03

Right now following schemes are valid:
```json
{
  "$ref": true
}
```
```json
{
  "$ref": "#",
  "type": "string"
}
```
etc.