### PR TITLE
Add JSEN to the list of JavaScript validators

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -9,7 +9,7 @@
 			_gaq.push(['_require', 'inpage_linkid', pluginUrl]);
 			_gaq.push(['_setAccount', 'UA-37169005-1']);
 			_gaq.push(['_trackPageview']);
-			
+
 			(function() {
 				var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
 				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
@@ -24,7 +24,7 @@
 				<h1>json-schema.org</h1>
 				<div class="tagline">The home of JSON Schema</div>
 			</div>
-			
+
 			<div class="page-content">
 				<div class="page-menu">
 				<a href=".">about</a> <a href="documentation.html">docs</a> <a href="examples.html">examples</a> <a class="selected" href="implementations.html">software</a> 				</div>
@@ -32,7 +32,7 @@
 				<div class="block">
 	<p>Implementations below are written in different languages, and support part, or all, of the
 	specification.</p>
-	
+
 	<p>Implementations below are classified based on their functionality.  When known, the
 	license of the project is also mentioned.</p>
 </div>
@@ -42,6 +42,7 @@
 <div class="block" id="validator-list">
 	<h3>JavaScript</h3>
 	<ul>
+		<li><a id="link-impl-jsen" href="https://github.com/bugventure/jsen">JSEN</a> - <em>supports version 4</em> (MIT)</li>
 		<li><a id="link-impl-ajv" href="https://github.com/epoberezkin/ajv">ajv</a> - <em>supports version 4</em> (MIT)</li>
 		<li><a id="link-impl-is-my-json-valid" href="https://github.com/mafintosh/is-my-json-valid">is-my-json-valid</a> - <em>supports version 4</em> (MIT)</li>
 		<li><a id="link-impl-tv4" href="http://geraintluff.github.com/tv4/">tv4</a> - <em>supports version 4</em> (Public Domain)</li>
@@ -107,12 +108,12 @@
 	<ul>
 		<li><a id="link-impl-wjelement" href="https://github.com/netmail-open/wjelement">WJElement</a> (LGPLv3)</li>
 	</ul>
-	
+
 	<h3>C++</h3>
 	<ul>
 		<li><a id="link-impl-libvariant" href="https://bitbucket.org/gallen/libvariant">LibVariant</a> (LGPLv2)</li>
 	</ul>
-	
+
 	<h3>Haskell</h3>
 	<ul>
 		<li><a id="link-impl-aeson-schema" href="https://github.com/timjb/aeson-schema">aeson-schema</a> (MIT)</li>
@@ -150,7 +151,7 @@
 	<ul>
 		<li><a id="link-impl-typson" href="https://github.com/lbovet/typson">Typson</a> (Apache 2.0)</li>
 	</ul>
-	
+
 	<h3>Visual Studio</h3>
 	<ul>
 		<li><a id="link-impl-vs" href="http://visualstudiogallery.msdn.microsoft.com/b4515ef8-a518-41ca-b48c-bb1fd4e6faf7">JSON Schema Generator</a> - free extension</li>
@@ -159,7 +160,7 @@
 	<h3>Python</h3>
 	<ul>
 		<li><a id="link-impl-jsl" href="https://github.com/aromanovich/jsl">JSL</a> (BSD) - a Python DSL for defining JSON Schemas</li>
-	</ul>	
+	</ul>
 </div>
 
 <div class="show-hide" data-target="parsing-list"></div>


### PR DESCRIPTION
For some reason JSEN is still missing from the list of validators on the live site. Sending another pull request for that.