### PR TITLE
Profile should be quoted

### DIFF
--- a/draft-zyp-json-schema-04.xml
+++ b/draft-zyp-json-schema-04.xml
@@ -219,7 +219,7 @@
                     <artwork>
 <![CDATA[
 Content-Type: application/my-media-type+json;
-              profile=http://json.com/my-hyper-schema
+              profile="http://json.com/my-hyper-schema"
 ]]>
                     </artwork>
                 </figure>


### PR DESCRIPTION
According to [RFC 2045 section 5.1](https://tools.ietf.org/html/rfc2045#section-5.1) when parameter value contains special symbols (like '/') it must include quotes.