### PR TITLE
adding everit-org/json-schema to the list implementations

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -59,6 +59,7 @@
 	<h3>Java</h3>
 	<ul>
 		<li><a id="link-impl-fge-json-schema-validator" href="https://github.com/fge/json-schema-validator">json-schema-validator</a> - <em>supports version 4</em> (LGPLv3)</li>
+		<li><a id="link-impl-everit-json-schema" href="https://github.com/everit-org/json-schema">json-schema (implementation based on the org.json API)</a> - <em>supports version 4</em> (Apache License 2.0)</li>
 	</ul>
 
 	<h3>Python</h3>


### PR DESCRIPTION
Recently I've created a new draftv4-compliant JSON Schema validator ( https://github.com/everit-org/json-schema/ ), please add it to the list of implementations.