### PR TITLE
Add Elixir validator ex_json_schema to the list of implementations

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -126,6 +126,11 @@
 		<li><a id="link-impl-jesse" href="https://github.com/klarna/jesse">JeSSE</a> (Apache 2.0)</li>
 	</ul>
 
+	<h3>Elixir</h3>
+	<ul>
+		<li><a id="link-impl-ex-json-schema" href="https://github.com/jonasschmidt/ex_json_schema">ex_json_schema</a> - <em>supports version 4</em> (MIT)</li>
+	</ul>
+
 	<h3>Go</h3>
 	<ul>
 		<li><a id="link-impl-gojsonschema" href="https://github.com/sigu-399/gojsonschema">gojsonschema</a> (Apache 2.0)</li>


### PR DESCRIPTION
I recently created a draft 4-compliant validator written in Elixir that passes the official test suite. Please add it to the list of implementations.
