### PR TITLE
Add Valijson to list of implementations

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -113,6 +113,7 @@
 	<h3>C++</h3>
 	<ul>
 		<li><a id="link-impl-libvariant" href="https://bitbucket.org/gallen/libvariant">LibVariant</a> (LGPLv2)</li>
+		<li><a id="link-impl-valijson" href="https://github.com/tristanpenman/valijson">Valijson</a> - header-only library, <em>supports version 4</em> (Simplified BSD)</li>
 	</ul>
 
 	<h3>Haskell</h3>


### PR DESCRIPTION
This library has been available for a couple of years now, and is being used in several other projects. I figured it was about time to add it to the official list.