### PR TITLE
Restore "$ref" to schema properties

### DIFF
--- a/draft-04/schema
+++ b/draft-04/schema
@@ -31,6 +31,10 @@
             "type": "string",
             "format": "uri"
         },
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
         "$schema": {
             "type": "string",
             "format": "uri"


### PR DESCRIPTION
Looks like this was (inadvertently?) removed in e14e3340c2c2e4f579cd3635b9b4e0e278161b7a. If it was removed on purpose, what was the reason?
