### PR TITLE
schema: Replace 'anyOf' with 'oneOf'.

### DIFF
--- a/draft-04/schema
+++ b/draft-04/schema
@@ -68,14 +68,14 @@
             "format": "regex"
         },
         "additionalItems": {
-            "anyOf": [
+            "oneOf": [
                 { "type": "boolean" },
                 { "$ref": "#" }
             ],
             "default": {}
         },
         "items": {
-            "anyOf": [
+            "oneOf": [
                 { "$ref": "#" },
                 { "$ref": "#/definitions/schemaArray" }
             ],
@@ -91,7 +91,7 @@
         "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
         "required": { "$ref": "#/definitions/stringArray" },
         "additionalProperties": {
-            "anyOf": [
+            "oneOf": [
                 { "type": "boolean" },
                 { "$ref": "#" }
             ],
@@ -115,7 +115,7 @@
         "dependencies": {
             "type": "object",
             "additionalProperties": {
-                "anyOf": [
+                "oneOf": [
                     { "$ref": "#" },
                     { "$ref": "#/definitions/stringArray" }
                 ]
@@ -127,7 +127,7 @@
             "uniqueItems": true
         },
         "type": {
-            "anyOf": [
+            "oneOf": [
                 { "$ref": "#/definitions/simpleTypes" },
                 {
                     "type": "array",


### PR DESCRIPTION
Simplified schema to show problem:

``` json
{
  "anyOf": [
    {
      "type": "boolean"
    },
    {
      "type": "object"
    }
  ]
}
```

It obvious that this two subschema couldn't be true at the same time.
So `anyOf` should be replaced with `oneOf`.

Such inconsistency confuses readers of `schema`, and serves as a bad example.
Moreover, it produces confusing errors when you validate your schemas.
